### PR TITLE
fix text: Raw Contract Address (start with 0x)

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1583,7 +1583,7 @@
 		"message": "Token has already been added."
 	},
 	"tokenContractAddress": {
-		"message": "Token Contract Address"
+		"message": "Token Raw Contract Address (start with 0x)"
 	},
 	"tokenOptions": {
 		"message": "Token options"

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -1543,7 +1543,7 @@
 		"message": "通证已添加。"
 	},
 	"tokenContractAddress": {
-		"message": "通证合约地址"
+		"message": "通证合约源地址（0x开头）"
 	},
 	"tokenOptions": {
 		"message": "通证选项"


### PR DESCRIPTION
文案修改：添加通证时，提示用户填写‘0x’开头的‘合约源地址’。